### PR TITLE
feat: Personalized feed implementation

### DIFF
--- a/backend/posts/tests.py
+++ b/backend/posts/tests.py
@@ -235,6 +235,11 @@ class PostOrderingTestCase(TestCase):
             name='Test Restaurant')
         self.tag = Tag.objects.create(ko_label='한식', en_label='Korean', type='from_category')
 
+                
+        # add tag to user_viewer
+        self.user_viewer.tags.add(self.tag)
+
+
         now = datetime.datetime.now()
         # post 1
         post_1 = Post.objects.create(
@@ -244,8 +249,7 @@ class PostOrderingTestCase(TestCase):
             description=f'Test Description Followed',
             created_at=now - timedelta(days=1)
         )
-        post_1.tags.add(self.tag)
-        
+
         # post 2
         post_2 = Post.objects.create(
             user=self.user_unfollowed,
@@ -255,6 +259,8 @@ class PostOrderingTestCase(TestCase):
             created_at=now - timedelta(days=2)
         )
         post_2.tags.add(self.tag)
+
+        
 
     def test_post_following(self):
         self.client.force_authenticate(user=self.user_viewer)
@@ -281,7 +287,11 @@ class PostOrderingTestCase(TestCase):
 
         # Check ordering
         self.assertTrue(
-            all(results[i]['created_at'] >= results[i + 1]['created_at']
+            all(results[i]['like_count'] >= results[i + 1]['like_count']
                 for i in range(len(results) - 1)),
-            "Posts are not ordered in reversed chronological order"
+            "Posts are not ordered in reverse like order"
         )
+        
+        # Check filtering
+        self.assertTrue(len(results['data']) == 1)
+        self.assertTrue(results['data'][0]['description'] == 'Test Description Unfollowed') # post 2

--- a/backend/posts/tests.py
+++ b/backend/posts/tests.py
@@ -1,11 +1,15 @@
+import datetime
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from django.contrib.auth import get_user_model
+from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from tags.models import Tag
-from users.models import User
+from users.models import Follow, User
 
 from .models import Post, PostPhoto, Restaurant
 
@@ -204,3 +208,80 @@ class PostCreateTestCase(APITestCase):
         Tag.objects.all().delete()
         Restaurant.objects.all().delete()
         User.objects.all().delete()
+
+
+class PostOrderingTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user_followed = get_user_model().objects.create_user(
+            username='testuser', password='12345')
+        
+        self.user_unfollowed = get_user_model().objects.create_user(
+            username='testuser2', password='12345')
+        
+        self.user_viewer = get_user_model().objects.create_user(
+            username='testuser3', password='12345')
+        
+        Follow.objects.create(follower=self.user_viewer, followee=self.user_followed)
+        
+        '''
+        Post 1 -> 내가 팔로우하고 있는 유저가 만들었고
+        Post 2 -> 그렇지 않음
+        
+        조회할 때는  -> Post 1만 내려와야 함.
+        '''
+        
+        self.restaurant = Restaurant.objects.create(
+            name='Test Restaurant')
+        self.tag = Tag.objects.create(ko_label='한식', en_label='Korean', type='from_category')
+
+        now = datetime.datetime.now()
+        # post 1
+        post_1 = Post.objects.create(
+            user=self.user_followed,
+            restaurant=self.restaurant,
+            rating=4.5,
+            description=f'Test Description Followed',
+            created_at=now - timedelta(days=1)
+        )
+        post_1.tags.add(self.tag)
+        
+        # post 2
+        post_2 = Post.objects.create(
+            user=self.user_unfollowed,
+            restaurant=self.restaurant,
+            rating=4.5,
+            description=f'Test Description Unfollowed',
+            created_at=now - timedelta(days=2)
+        )
+        post_2.tags.add(self.tag)
+
+    def test_post_following(self):
+        self.client.force_authenticate(user=self.user_viewer)
+        response = self.client.get('/posts/following/')
+        self.assertEqual(response.status_code, 200)
+        results = response.json()
+
+        # Check ordering
+        self.assertTrue(
+            all(results[i]['created_at'] >= results[i + 1]['created_at']
+                for i in range(len(results) - 1)),
+            "Posts are not ordered in reversed chronological order"
+        )
+        
+        # Check filtering
+        self.assertTrue(len(results['data']) == 1)
+        self.assertTrue(results['data'][0]['description'] == 'Test Description Followed')
+        
+    def test_post_recommend(self):
+        self.client.force_authenticate(user=self.user_viewer)
+        response = self.client.get('/posts/recommend/')
+        self.assertEqual(response.status_code, 200)
+        results = response.json()
+
+        # Check ordering
+        self.assertTrue(
+            all(results[i]['created_at'] >= results[i + 1]['created_at']
+                for i in range(len(results) - 1)),
+            "Posts are not ordered in reversed chronological order"
+        )

--- a/backend/posts/views.py
+++ b/backend/posts/views.py
@@ -133,6 +133,28 @@ class PostViewSet(viewsets.ModelViewSet):
         queryset = self.get_queryset()
         serializer = self.get_serializer(queryset, many=True, context={"request": request})
         return Response({"data": serializer.data})
+    
+    @action(detail=False, methods=['get'], url_path='following', permission_classes=[permissions.IsAuthenticated], serializer_class=PostSerializer)
+    def list_following(self, request):
+        user = request.user
+        following = user.following.all()
+        posts = Post.objects.filter(user__in=following)
+        serializer = self.get_serializer(posts, many=True, context={"request": request})
+        return Response({"data": serializer.data})
+    
+    '''
+    select * from posts; -> Post.objects.all()
+    select * from posts where id = 1 -> Post.objects.filter(id=1)
+    '''
+
+    @action(detail=False, methods=['get'], url_path='recommend', permission_classes=[permissions.IsAuthenticated], serializer_class=PostSerializer)
+    def list_recommend(self, request):
+        queryset = self.get_queryset()
+        serializer = self.get_serializer(
+            queryset, many=True, context={"request": request})
+        return Response({"data": serializer.data})
+
+
 
     @action(detail=True, methods=['put'], url_path='likes', permission_classes=[permissions.IsAuthenticated], serializer_class=None)
     def like_post(self, request, pk=None):


### PR DESCRIPTION
### PR Title: Implement personalized feed
#### Related Issue(s):
- X
#### PR Description:
- Implemented two endpoints related to Personalized feed: `/posts/following` and `/posts/recommend`
- `/posts/following` gives posts of following users only, and orders post by created_at
- `/posts/recommend` orders post by number of intersecting tags of viewing user and each post. If intersecting tags are equal, order by like_count
- Added related tests


##### Changes Included:
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
-
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
